### PR TITLE
Added Tooltips for Seats

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,49 +29,70 @@ yarn add react-seat-picker
 ## Usage
 
 ```jsx
-import React, { Component } from 'react'
+import React, {Component} from 'react'
 
 import SeatPicker from 'react-seat-picker'
 
-class Example extends Component {
+export default class App extends Component {
   state = {
-    loading:false
+    loading: false
   }
-  addSeatCallback=(row, number, id, cb)=>{
+
+  addSeatCallback = (row, number, id, cb) => {
     this.setState({
-      loading:true
-    },async()=>{
-      await new Promise(resolve => setTimeout(resolve, 5000));
+      loading: true
+    }, async () => {
+      await new Promise(resolve => setTimeout(resolve, 1500))
       console.log(`Added seat ${number}, row ${row}, id ${id}`)
-      cb(row,number)
-      this.setState({ loading: false })
+      const newTooltip = `tooltip for id-${id} added by callback`
+      cb(row, number, newTooltip)
+      this.setState({loading: false})
     })
   }
-  render () {
+
+  removeSeatCallback = (row, number, id, cb) => {
+    this.setState({
+      loading: true
+    }, async () => {
+      await new Promise(resolve => setTimeout(resolve, 1500))
+      console.log(`Removed seat ${number}, row ${row}, id ${id}`)
+
+      // A value of null will reset the tooltip to the original while '' will hide the tooltip
+      const newTooltip = ['A', 'B', 'C'].includes(row) ? null : ''
+
+      cb(row, number, newTooltip)
+      this.setState({loading: false})
+    })
+  }
+
+  render() {
     const rows = [
-      [{ id:1, number: 1, isSelected: true }, { id:2, number: 2}, null, { id:3, number: '3', isReserved: true, orientation: 'east'}, { id:4, number: '4', orientation: 'west'}, null, { id:5, number: 5}, { id:6, number: 6}],
-      [{ id:7, number: 1, isReserved: true }, { id:8, number: 2, isReserved: true}, null, { id:9, number: '3', isReserved: true, orientation: 'east'}, { id:10, number: '4', orientation: 'west'}, null, { id:11, number: 5}, { id:12, number: 6}],
-      [{ id:13, number: 1 }, { id:14, number: 2}, null, { id:15, number: 3, isReserved: true, orientation: 'east'}, { id:16, number: '4', orientation: 'west'}, null, { id:17, number: 5}, { id:18, number: 6}],
-      [{ id:19, number: 1 }, { id:20, number: 2}, null, { id:21, number: 3, orientation: 'east'}, { id:22, number: '4', orientation: 'west'}, null, { id:23, number: 5}, { id:24, number: 6}],
-      [{ id:25, number: 1, isReserved: true }, { id:26, number: 2, orientation: 'east'}, null, { id:27, number: '3', isReserved: true}, { id:28, number: '4', orientation: 'west'}, null, { id:29, number: 5}, { id:30, number: 6, isReserved: true}]
+      [{id: 1, number: 1, isSelected: true, tooltip: 'Reserved by you'}, {id: 2, number: 2, tooltip: 'Cost: 15$'}, null, {id: 3, number: '3', isReserved: true, orientation: 'east', tooltip: 'Reserved by Rogger'}, {id: 4, number: '4', orientation: 'west'}, null, {id: 5, number: 5}, {id: 6, number: 6}],
+      [{id: 7, number: 1, isReserved: true, tooltip: 'Reserved by Matthias Nadler'}, {id: 8, number: 2, isReserved: true}, null, {id: 9, number: '3', isReserved: true, orientation: 'east'}, {id: 10, number: '4', orientation: 'west'}, null, {id: 11, number: 5}, {id: 12, number: 6}],
+      [{id: 13, number: 1}, {id: 14, number: 2}, null, {id: 15, number: 3, isReserved: true, orientation: 'east'}, {id: 16, number: '4', orientation: 'west'}, null, {id: 17, number: 5}, {id: 18, number: 6}],
+      [{id: 19, number: 1, tooltip: 'Cost: 25$'}, {id: 20, number: 2}, null, {id: 21, number: 3, orientation: 'east'}, {id: 22, number: '4', orientation: 'west'}, null, {id: 23, number: 5}, {id: 24, number: 6}],
+      [{id: 25, number: 1, isReserved: true}, {id: 26, number: 2, orientation: 'east'}, null, {id: 27, number: '3', isReserved: true}, {id: 28, number: '4', orientation: 'west'}, null,{id: 29, number: 5, tooltip: 'Cost: 11$'}, {id: 30, number: 6, isReserved: true}]
     ]
-    const {loading}=this.state
+    const {loading} = this.state
     return (
       <div>
         <h1>Seat Picker</h1>
-        <SeatPicker
-          addSeatCallback={this.addSeatCallback}
-          rows={rows}
-          maxReservableSeats={3}
-          alpha
-          visible
-          selectedByDefault
-          loading={loading}
-         />
+        <div style={{marginTop: '200px'}}>
+          <SeatPicker
+            addSeatCallback={this.addSeatCallback}
+            removeSeatCallback={this.removeSeatCallback}
+            rows={rows}
+            maxReservableSeats={3}
+            alpha
+            visible
+            selectedByDefault
+            loading={loading}
+            tooltipProps={{multiline: true}}
+          />
+        </div>
       </div>
     )
   }
-}
 ```
 
 ### Props
@@ -85,6 +106,7 @@ Name | Type | Default | Required|Description
 `maxReservableSeats` | number | 0 | `false` | Limits the number of selectable seats.
 `addSeatCallback` | function | (row, number, id, cb) => {console.log( `Added seat ${number}, row ${row}, id ${id}`); cb(row,number)} | `false` | Should be customized as you need. Remember to use cb(row,number) for accepting the selection, otherwise ommit it.
 `removeSeatCallback` | function | (row, number, id, cb) => {console.log( `Removed seat ${number}, row ${row}, id ${id}`); cb(row,number)} | `false` | Should be customized as you need. Remember to use cb(row,number) for accepting the deselection, otherwise ommit it.
+`tooltipProps` | object | - | `false` | An object with props (options) for the [react-tooltip](https://www.npmjs.com/package/react-tooltip) components.
 `rows` | array | - | `true` | Array of arrays of json. (See next section).
 
 ### Seats properties
@@ -95,6 +117,7 @@ Name | Type | Default | Required|Description
 ---- | ----- | ------- | ------ | -----------
 `id` | number or string | undefined | `false` | It identify a seat.
 `number` | number or string | undefined | `false` | It will be showed inside seat.
+`tooltip` | string | undefined | `false` | Text of the tooltip when hovering over the seat.
 `isSelected` | boolean | `false` | `false` | It will be checked in case selectedByDefault is true.
 `isReserved` | boolean | `false` | `false` | Disable the option of click it.
 `orientation` | string | north | `false` | Define the position of an specific seat (north, south, east, west).

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -6,11 +6,12 @@ export default class App extends Component {
   state = {
     loading: false
   }
+
   addSeatCallback = (row, number, id, cb) => {
     this.setState({
       loading: true
     }, async () => {
-      await new Promise(resolve => setTimeout(resolve, 300))
+      await new Promise(resolve => setTimeout(resolve, 1500))
       console.log(`Added seat ${number}, row ${row}, id ${id}`)
       const newTooltip = `tooltip for id-${id} added by callback`
       cb(row, number, newTooltip)
@@ -22,12 +23,10 @@ export default class App extends Component {
     this.setState({
       loading: true
     }, async () => {
-      await new Promise(resolve => setTimeout(resolve, 300))
+      await new Promise(resolve => setTimeout(resolve, 1500))
       console.log(`Removed seat ${number}, row ${row}, id ${id}`)
-
       // A value of null will reset the tooltip to the original while '' will hide the tooltip
-      const newTooltip = ''
-
+      const newTooltip = ['A', 'B', 'C'].includes(row) ? null : ''
       cb(row, number, newTooltip)
       this.setState({loading: false})
     })
@@ -36,18 +35,18 @@ export default class App extends Component {
   render() {
     const rows = [
       [{id: 1, number: 1, isSelected: true, tooltip: 'Reserved by you'}, {id: 2, number: 2, tooltip: 'Cost: 15$'},
-        null, {id: 3, number: '3', isReserved: true, orientation: 'east', tooltip: 'Reserved by Matthias Nadler'},
+        null, {id: 3, number: '3', isReserved: true, orientation: 'east', tooltip: 'Reserved by Rogger'},
         {id: 4, number: '4', orientation: 'west'}, null, {id: 5, number: 5}, {id: 6, number: 6}],
-      [{id: 7, number: 1, isReserved: true}, {id: 8, number: 2, isReserved: true}, null,
+      [{id: 7, number: 1, isReserved: true, tooltip: 'Reserved by Matthias Nadler'}, {id: 8, number: 2, isReserved: true}, null,
         {id: 9, number: '3', isReserved: true, orientation: 'east'}, {id: 10, number: '4', orientation: 'west'},
         null, {id: 11, number: 5}, {id: 12, number: 6}],
       [{id: 13, number: 1}, {id: 14, number: 2}, null, {id: 15, number: 3, isReserved: true, orientation: 'east'},
         {id: 16, number: '4', orientation: 'west'}, null, {id: 17, number: 5}, {id: 18, number: 6}],
-      [{id: 19, number: 1}, {id: 20, number: 2}, null, {id: 21, number: 3, orientation: 'east'},
+      [{id: 19, number: 1, tooltip: 'Cost: 25$'}, {id: 20, number: 2}, null, {id: 21, number: 3, orientation: 'east'},
         {id: 22, number: '4', orientation: 'west'}, null, {id: 23, number: 5}, {id: 24, number: 6}],
       [{id: 25, number: 1, isReserved: true}, {id: 26, number: 2, orientation: 'east'}, null,
         {id: 27, number: '3', isReserved: true}, {id: 28, number: '4', orientation: 'west'}, null,
-        {id: 29, number: 5, tooltip: 'asdf'}, {id: 30, number: 6, isReserved: true}]
+        {id: 29, number: 5, tooltip: 'Cost: 11$'}, {id: 30, number: 6, isReserved: true}]
     ]
     const {loading} = this.state
     return (

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -10,51 +10,44 @@ export default class App extends Component {
     this.setState({
       loading: true
     }, async () => {
-      await new Promise(resolve => setTimeout(resolve, 500))
+      await new Promise(resolve => setTimeout(resolve, 300))
       console.log(`Added seat ${number}, row ${row}, id ${id}`)
-      cb(row, number)
+      const newTooltip = `tooltip for id-${id} added by callback`
+      cb(row, number, newTooltip)
+      this.setState({loading: false})
+    })
+  }
+
+  removeSeatCallback = (row, number, id, cb) => {
+    this.setState({
+      loading: true
+    }, async () => {
+      await new Promise(resolve => setTimeout(resolve, 300))
+      console.log(`Removed seat ${number}, row ${row}, id ${id}`)
+
+      // A value of null will reset the tooltip to the original while '' will hide the tooltip
+      const newTooltip = ''
+
+      cb(row, number, newTooltip)
       this.setState({loading: false})
     })
   }
 
   render() {
     const rows = [
-      [{id: 1, number: 1, isSelected: true, tooltip: 'testtooltip'}, {
-        id: 2,
-        number: 2,
-        tooltip: 'asdasdlkj sdlkasdlök0sjad \n alsjkd alkdj kaldöj adslöj alsdkja'
-      }, null, {id: 3, number: '3', isReserved: true, orientation: 'east'}, {
-        id: 4,
-        number: '4',
-        orientation: 'west'
-      }, null, {id: 5, number: 5}, {id: 6, number: 6}],
-      [{id: 7, number: 1, isReserved: true}, {id: 8, number: 2, isReserved: true}, null, {
-        id: 9,
-        number: '3',
-        isReserved: true,
-        orientation: 'east',
-        tooltip: 'asdfk'
-      }, {id: 10, number: '4', orientation: 'west'}, null, {id: 11, number: 5}, {id: 12, number: 6}],
-      [{id: 13, number: 1}, {id: 14, number: 2}, null, {
-        id: 15,
-        number: 3,
-        isReserved: true,
-        orientation: 'east'
-      }, {id: 16, number: '4', orientation: 'west'}, null, {id: 17, number: 5}, {id: 18, number: 6}],
-      [{id: 19, number: 1}, {id: 20, number: 2}, null, {id: 21, number: 3, orientation: 'east'}, {
-        id: 22,
-        number: '4',
-        orientation: 'west'
-      }, null, {id: 23, number: 5}, {id: 24, number: 6}],
-      [{id: 25, number: 1, isReserved: true}, {id: 26, number: 2, orientation: 'east'}, null, {
-        id: 27,
-        number: '3',
-        isReserved: true
-      }, {id: 28, number: '4', orientation: 'west'}, null, {id: 29, number: 5, tooltip: 'asdf'}, {
-        id: 30,
-        number: 6,
-        isReserved: true
-      }]
+      [{id: 1, number: 1, isSelected: true, tooltip: 'Reserved by you'}, {id: 2, number: 2, tooltip: 'Cost: 15$'},
+        null, {id: 3, number: '3', isReserved: true, orientation: 'east', tooltip: 'Reserved by Matthias Nadler'},
+        {id: 4, number: '4', orientation: 'west'}, null, {id: 5, number: 5}, {id: 6, number: 6}],
+      [{id: 7, number: 1, isReserved: true}, {id: 8, number: 2, isReserved: true}, null,
+        {id: 9, number: '3', isReserved: true, orientation: 'east'}, {id: 10, number: '4', orientation: 'west'},
+        null, {id: 11, number: 5}, {id: 12, number: 6}],
+      [{id: 13, number: 1}, {id: 14, number: 2}, null, {id: 15, number: 3, isReserved: true, orientation: 'east'},
+        {id: 16, number: '4', orientation: 'west'}, null, {id: 17, number: 5}, {id: 18, number: 6}],
+      [{id: 19, number: 1}, {id: 20, number: 2}, null, {id: 21, number: 3, orientation: 'east'},
+        {id: 22, number: '4', orientation: 'west'}, null, {id: 23, number: 5}, {id: 24, number: 6}],
+      [{id: 25, number: 1, isReserved: true}, {id: 26, number: 2, orientation: 'east'}, null,
+        {id: 27, number: '3', isReserved: true}, {id: 28, number: '4', orientation: 'west'}, null,
+        {id: 29, number: 5, tooltip: 'asdf'}, {id: 30, number: 6, isReserved: true}]
     ]
     const {loading} = this.state
     return (
@@ -63,6 +56,7 @@ export default class App extends Component {
         <div style={{marginTop: '200px'}}>
           <SeatPicker
             addSeatCallback={this.addSeatCallback}
+            removeSeatCallback={this.removeSeatCallback}
             rows={rows}
             maxReservableSeats={3}
             alpha

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,42 +1,77 @@
-import React, { Component } from 'react'
+import React, {Component} from 'react'
 
 import SeatPicker from 'react-seat-picker'
 
 export default class App extends Component {
   state = {
-    loading:false
+    loading: false
   }
-  addSeatCallback=(row, number, id, cb)=>{
+  addSeatCallback = (row, number, id, cb) => {
     this.setState({
-      loading:true
-    },async()=>{
-      await new Promise(resolve => setTimeout(resolve, 5000));
+      loading: true
+    }, async () => {
+      await new Promise(resolve => setTimeout(resolve, 500))
       console.log(`Added seat ${number}, row ${row}, id ${id}`)
-      cb(row,number)
-      this.setState({ loading: false })
+      cb(row, number)
+      this.setState({loading: false})
     })
   }
-  render () {
+
+  render() {
     const rows = [
-      [{ id:1, number: 1, isSelected: true }, { id:2, number: 2}, null, { id:3, number: '3', isReserved: true, orientation: 'east'}, { id:4, number: '4', orientation: 'west'}, null, { id:5, number: 5}, { id:6, number: 6}],
-      [{ id:7, number: 1, isReserved: true }, { id:8, number: 2, isReserved: true}, null, { id:9, number: '3', isReserved: true, orientation: 'east'}, { id:10, number: '4', orientation: 'west'}, null, { id:11, number: 5}, { id:12, number: 6}],
-      [{ id:13, number: 1 }, { id:14, number: 2}, null, { id:15, number: 3, isReserved: true, orientation: 'east'}, { id:16, number: '4', orientation: 'west'}, null, { id:17, number: 5}, { id:18, number: 6}],
-      [{ id:19, number: 1 }, { id:20, number: 2}, null, { id:21, number: 3, orientation: 'east'}, { id:22, number: '4', orientation: 'west'}, null, { id:23, number: 5}, { id:24, number: 6}],
-      [{ id:25, number: 1, isReserved: true }, { id:26, number: 2, orientation: 'east'}, null, { id:27, number: '3', isReserved: true}, { id:28, number: '4', orientation: 'west'}, null, { id:29, number: 5}, { id:30, number: 6, isReserved: true}]
+      [{id: 1, number: 1, isSelected: true, tooltip: 'testtooltip'}, {
+        id: 2,
+        number: 2,
+        tooltip: 'asdasdlkj sdlkasdlök0sjad \n alsjkd alkdj kaldöj adslöj alsdkja'
+      }, null, {id: 3, number: '3', isReserved: true, orientation: 'east'}, {
+        id: 4,
+        number: '4',
+        orientation: 'west'
+      }, null, {id: 5, number: 5}, {id: 6, number: 6}],
+      [{id: 7, number: 1, isReserved: true}, {id: 8, number: 2, isReserved: true}, null, {
+        id: 9,
+        number: '3',
+        isReserved: true,
+        orientation: 'east',
+        tooltip: 'asdfk'
+      }, {id: 10, number: '4', orientation: 'west'}, null, {id: 11, number: 5}, {id: 12, number: 6}],
+      [{id: 13, number: 1}, {id: 14, number: 2}, null, {
+        id: 15,
+        number: 3,
+        isReserved: true,
+        orientation: 'east'
+      }, {id: 16, number: '4', orientation: 'west'}, null, {id: 17, number: 5}, {id: 18, number: 6}],
+      [{id: 19, number: 1}, {id: 20, number: 2}, null, {id: 21, number: 3, orientation: 'east'}, {
+        id: 22,
+        number: '4',
+        orientation: 'west'
+      }, null, {id: 23, number: 5}, {id: 24, number: 6}],
+      [{id: 25, number: 1, isReserved: true}, {id: 26, number: 2, orientation: 'east'}, null, {
+        id: 27,
+        number: '3',
+        isReserved: true
+      }, {id: 28, number: '4', orientation: 'west'}, null, {id: 29, number: 5, tooltip: 'asdf'}, {
+        id: 30,
+        number: 6,
+        isReserved: true
+      }]
     ]
-    const {loading}=this.state
+    const {loading} = this.state
     return (
       <div>
         <h1>Seat Picker</h1>
-        <SeatPicker
-          addSeatCallback={this.addSeatCallback}
-          rows={rows}
-          maxReservableSeats={3}
-          alpha
-          visible
-          selectedByDefault
-          loading={loading}
-         />
+        <div style={{marginTop: '200px'}}>
+          <SeatPicker
+            addSeatCallback={this.addSeatCallback}
+            rows={rows}
+            maxReservableSeats={3}
+            alpha
+            visible
+            selectedByDefault
+            loading={loading}
+            tooltipProps={{multiline: true}}
+          />
+        </div>
       </div>
     )
   }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "peerDependencies": {
     "prop-types": "^15.5.4",
     "react": "^15.0.0 || ^16.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0"
+    "react-dom": "^15.0.0 || ^16.0.0",
+    "react-tooltip": "^3.11.1"
   },
   "devDependencies": {
     "@svgr/rollup": "^2.4.1",
@@ -59,6 +60,7 @@
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
     "react-scripts": "^1.1.4",
+    "react-tooltip": "^3.11.1",
     "rimraf": "^3.0.0",
     "rollup": "^0.64.1",
     "rollup-plugin-babel": "^3.0.7",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A React component to select seats.",
   "author": "Rogger794",
   "license": "MIT",
-  "repository": "Rogger794/react-seat-picker",
+  "repository": "matnad/react-seat-picker",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
   "jsnext:main": "dist/index.es.js",

--- a/src/SeatPicker/Seat.js
+++ b/src/SeatPicker/Seat.js
@@ -1,16 +1,8 @@
-import React, { Component } from 'react'
+import React, {Component} from 'react'
 import PropTypes from 'prop-types'
+import ReactTooltip from 'react-tooltip'
 
 export default class Seat extends Component {
-  static propTypes = {
-    isSelected: PropTypes.bool,
-    isReserved: PropTypes.bool,
-    isEnabled: PropTypes.bool,
-    orientation: PropTypes.oneOf([ 'north', 'south', 'east', 'west' ]),
-    seatNumber: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    selectSeat: PropTypes.func.isRequired
-  }
-
   static defaultProps = {
     isSelected: false
   }
@@ -19,17 +11,29 @@ export default class Seat extends Component {
     !this.props.isReserved && this.props.selectSeat()
   }
 
-  render () {
-    const { isSelected, isEnabled, isReserved, orientation } = this.props
+  render() {
+    const {isSelected, tooltip, isEnabled, isReserved, orientation} = this.props
     const className = 'seat' +
-        (isSelected ? ' seat--selected' : '') +
-        (!isSelected && isEnabled && !isReserved ? ' seat--enabled' : '') +
-        (isReserved ? ' seat--reserved' : '') +
-        (` seat--${!orientation ? 'north' : orientation}`)
+      (isSelected ? ' seat--selected' : '') +
+      (!isSelected && isEnabled && !isReserved ? ' seat--enabled' : '') +
+      (isReserved ? ' seat--reserved' : '') +
+      (` seat--${!orientation ? 'north' : orientation}`)
     return (
-      <div className={className} onClick={this.handleClick}>
+      <div data-tip={tooltip} className={className} onClick={this.handleClick}>
+        {tooltip ? <ReactTooltip {...this.props.tooltipProps} /> : null}
         <span className='seat__number'>{this.props.seatNumber}</span>
       </div>
     )
   }
+}
+
+Seat.propTypes = {
+  isSelected: PropTypes.bool,
+  isReserved: PropTypes.bool,
+  tooltip: PropTypes.string,
+  isEnabled: PropTypes.bool,
+  orientation: PropTypes.oneOf(['north', 'south', 'east', 'west']),
+  seatNumber: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  selectSeat: PropTypes.func.isRequired,
+  tooltipProps: PropTypes.object
 }

--- a/src/SeatPicker/SeatPicker.js
+++ b/src/SeatPicker/SeatPicker.js
@@ -1,43 +1,25 @@
-import React, { Component } from 'react'
+import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import Row from './Row'
 import Seat from './Seat'
 import Blank from './Blank'
 
 export class SeatPicker extends Component {
-  static propTypes = {
-    addSeatCallback: PropTypes.func,
-    alpha: PropTypes.bool,
-    visible: PropTypes.bool,
-    selectedByDefault: PropTypes.bool,
-    removeSeatCallback: PropTypes.func,
-    maxReservableSeats: PropTypes.number,
-    rows: PropTypes.arrayOf(
-      PropTypes.arrayOf(
-        PropTypes.shape({
-          number: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-          isReserved: PropTypes.bool,
-          isSelected: PropTypes.bool
-        })
-      )
-    ).isRequired
-  }
-
   static defaultProps = {
     addSeatCallback: (row, number, id, cb) => {
       console.log(`Added seat ${number}, row ${row}, id ${id}`)
-      cb(row,number)
+      cb(row, number)
     },
-    removeSeatCallback: (row, number, id,cb) => {
+    removeSeatCallback: (row, number, id, cb) => {
       console.log(`Removed seat ${number}, row ${row}, id ${id}`)
-      cb(row,number)
+      cb(row, number)
     },
     maxReservableSeats: 0
   }
 
-  constructor (props) {
+  constructor(props) {
     super(props)
-    const { rows } = props
+    const {rows} = props
     const {selectedSeats, size} = this.getAlreadySelectedSeats()
     this.state = {
       selectedSeats: selectedSeats,
@@ -46,10 +28,11 @@ export class SeatPicker extends Component {
     }
   }
 
-  static getDerivedStateFromProps (props, state) {
+  static getDerivedStateFromProps(props, state) {
     if (props.maxReservableSeats < state.size) {
       let sum = 0
       let selectedSeats = {}
+      // eslint-disable-next-line no-unused-vars
       for (let array in state.selectedSeats) {
         if (
           sum + state.selectedSeats[array].length <
@@ -70,8 +53,8 @@ export class SeatPicker extends Component {
     return null
   }
 
-  shouldComponentUpdate (nextProps, nextState) {
-    return nextState.selectedSeats !== this.state.selectedSeats || this.props.loading!==nextProps.loading
+  shouldComponentUpdate(nextProps, nextState) {
+    return nextState.selectedSeats !== this.state.selectedSeats || this.props.loading !== nextProps.loading
   }
 
   getAlreadySelectedSeats = () => {
@@ -101,14 +84,14 @@ export class SeatPicker extends Component {
     return {selectedSeats, size}
   }
 
-  includeSeat=(selectedSeats, row, number) => {
+  includeSeat = (selectedSeats, row, number) => {
     if (selectedSeats[row]) {
       return selectedSeats[row].includes(number)
     }
     return false
   }
 
-  addSeat=(selectedSeats, row, number) => {
+  addSeat = (selectedSeats, row, number) => {
     if (selectedSeats[row]) {
       if (!selectedSeats[row].includes(number)) {
         selectedSeats[row].push(number)
@@ -120,8 +103,8 @@ export class SeatPicker extends Component {
     return {...selectedSeats}
   }
 
-  deleteSeat=(row, number) => {
-    let { selectedSeats } = this.state
+  deleteSeat = (row, number) => {
+    let {selectedSeats} = this.state
     if (selectedSeats[row]) {
       selectedSeats[row] = selectedSeats[row].filter((value) => {
         return value !== number
@@ -133,10 +116,10 @@ export class SeatPicker extends Component {
     return {...selectedSeats}
   }
 
-  acceptSelection= (row, number) => {
-    let { selectedSeats } = this.state
+  acceptSelection = (row, number) => {
+    let {selectedSeats} = this.state
     const size = this.state.size
-    
+
     this.setState(
       {
         selectedSeats: this.addSeat(selectedSeats, row, number),
@@ -145,9 +128,9 @@ export class SeatPicker extends Component {
     )
   }
 
-  acceptDeselection= (row, number) => {
+  acceptDeselection = (row, number) => {
     const size = this.state.size
-    
+
     this.setState(
       {
         selectedSeats: this.deleteSeat(row, number),
@@ -157,7 +140,7 @@ export class SeatPicker extends Component {
   }
 
   selectSeat = (row, number, id) => {
-    let { selectedSeats } = this.state
+    let {selectedSeats} = this.state
     const size = this.state.size
     const {
       maxReservableSeats,
@@ -167,24 +150,24 @@ export class SeatPicker extends Component {
     const seatAlreadySelected = this.includeSeat(selectedSeats, row, number)
 
     if (size < maxReservableSeats && !seatAlreadySelected) {
-      addSeatCallback(row, number, id,this.acceptSelection)
+      addSeatCallback(row, number, id, this.acceptSelection)
     } else if (selectedSeats[row] && seatAlreadySelected) {
       removeSeatCallback(row, number, id, this.acceptDeselection)
     }
   }
 
-  render () {
-    return<div className='seat-content'>
-            <div className={this.props.loading?'loader':null}></div> 
-            <div className='seat-picker'>
-              {this.renderRows()}
-            </div>
-          </div>
+  render() {
+    return <div className='seat-content'>
+      <div className={this.props.loading ? 'loader' : null}></div>
+      <div className='seat-picker'>
+        {this.renderRows()}
+      </div>
+    </div>
   }
 
-  renderRows () {
-    const { selectedSeats: seats } = this.state
-    const { alpha, visible } = this.props
+  renderRows() {
+    const {selectedSeats: seats} = this.state
+    const {alpha, visible} = this.props
     return this.props.rows.map((row, index) => {
       const rowNumber = alpha
         ? String.fromCharCode('A'.charCodeAt(0) + index)
@@ -206,30 +189,52 @@ export class SeatPicker extends Component {
     })
   }
 
-  renderSeats (seats, rowNumber, isRowSelected) {
-    const { selectedSeats, size, rowLength } = this.state
-    const { maxReservableSeats } = this.props
+  renderSeats(seats, rowNumber, isRowSelected) {
+    const {selectedSeats, size, rowLength} = this.state
+    const {maxReservableSeats} = this.props
     const blanks = new Array((rowLength - seats.length) > 0 ? (rowLength - seats.length) : 0).fill(0)
     let row = seats.map((seat, index) => {
-      if (seat === null) return <Blank key={index} />
+      if (seat === null) return <Blank key={index}/>
       const isSelected =
         isRowSelected && this.includeSeat(selectedSeats, rowNumber, seat.number)
       const props = {
         isSelected,
         orientation: seat.orientation,
         isReserved: seat.isReserved,
+        tooltip: seat.tooltip,
         isEnabled: size < maxReservableSeats,
         selectSeat: this.selectSeat.bind(this, rowNumber, seat.number, seat.id),
         seatNumber: seat.number,
-        key: index
+        key: index,
+        tooltipProps: this.props.tooltipProps
       }
       return <Seat {...props} />
     })
     if (blanks.length > 0) {
       blanks.forEach((blank, index) => {
-        row.push(<Blank key={row.length + index + 1} />)
+        row.push(<Blank key={row.length + index + 1}/>)
       })
     }
     return row
   }
+}
+
+SeatPicker.propTypes = {
+  addSeatCallback: PropTypes.func,
+  alpha: PropTypes.bool,
+  visible: PropTypes.bool,
+  selectedByDefault: PropTypes.bool,
+  removeSeatCallback: PropTypes.func,
+  maxReservableSeats: PropTypes.number,
+  rows: PropTypes.arrayOf(
+    PropTypes.arrayOf(
+      PropTypes.shape({
+        number: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        isReserved: PropTypes.bool,
+        tooltip: PropTypes.string,
+        isSelected: PropTypes.bool
+      })
+    )
+  ).isRequired,
+  tooltipProps: PropTypes.object
 }

--- a/src/SeatPicker/SeatPicker.js
+++ b/src/SeatPicker/SeatPicker.js
@@ -209,9 +209,6 @@ export class SeatPicker extends Component {
       if (tooltipOverrides[rowNumber] && tooltipOverrides[rowNumber][seat.number] != null) {
         tooltip = tooltipOverrides[rowNumber][seat.number]
       }
-      if (rowNumber === 'A') {
-        console.log(tooltip)
-      }
       const props = {
         isSelected,
         orientation: seat.orientation,

--- a/src/SeatPicker/SeatPicker.js
+++ b/src/SeatPicker/SeatPicker.js
@@ -33,7 +33,6 @@ export class SeatPicker extends Component {
     if (props.maxReservableSeats < state.size) {
       let sum = 0
       let selectedSeats = {}
-      // eslint-disable-next-line no-unused-vars
       for (let array in state.selectedSeats) {
         if (
           sum + state.selectedSeats[array].length <
@@ -167,7 +166,7 @@ export class SeatPicker extends Component {
 
   render() {
     return <div className='seat-content'>
-      <div className={this.props.loading ? 'loader' : null}></div>
+      <div className={this.props.loading ? 'loader' : null} />
       <div className='seat-picker'>
         {this.renderRows()}
       </div>
@@ -203,11 +202,11 @@ export class SeatPicker extends Component {
     const {maxReservableSeats} = this.props
     const blanks = new Array((rowLength - seats.length) > 0 ? (rowLength - seats.length) : 0).fill(0)
     let row = seats.map((seat, index) => {
-      if (seat === null) return <Blank key={index}/>
+      if (seat === null) return <Blank key={index} />
       const isSelected =
         isRowSelected && this.includeSeat(selectedSeats, rowNumber, seat.number)
       let tooltip = seat.tooltip
-      if (tooltipOverrides[rowNumber] && tooltipOverrides[rowNumber][seat.number] !== null) {
+      if (tooltipOverrides[rowNumber] && tooltipOverrides[rowNumber][seat.number] != null) {
         tooltip = tooltipOverrides[rowNumber][seat.number]
       }
       const props = {
@@ -225,7 +224,7 @@ export class SeatPicker extends Component {
     })
     if (blanks.length > 0) {
       blanks.forEach((blank, index) => {
-        row.push(<Blank key={row.length + index + 1}/>)
+        row.push(<Blank key={row.length + index + 1} />)
       })
     }
     return row


### PR DESCRIPTION
Demo: https://matnad.github.io/react-seat-picker/

New Feature **Tooltips for Seats**:
- New optional Seat Property called `tooltip`
- When given a string, will display the string as a tooltip on hover
- Tooltips can be directly modified with the callback functions including hiding them or restoring the original string
- The tooltip uses the react-tooltip component and the seat-picker now accepts the props for react-tooltip to pass on

Additional changes:
- Fixed all linting errors according to ES6 standards (mostly reformatting, very minor refactoring)
- Moved propTypes out of the constructor to avoid the babel plugin (this makes it compatible with cra)
- Changed the example and readme to reflect the new feature

Note: If you accept the PR, change back the repo in the package.json file!

I'm open for discussion and suggestions on the feature.